### PR TITLE
Trigger Pages workflow on both main and master branches

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,44 @@
+name: Deploy Jekyll site to Pages
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: .
+          destination: ./_site
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
### Motivation
- Ensure the GitHub Pages workflow runs whether the repository uses `main` or `master` as the default branch to address CI trigger mismatch reported in the inline comment.

### Description
- Updated `.github/workflows/pages.yml` to list both `main` and `master` under `on.push.branches` so pushes to either branch trigger the workflow.
- Kept `workflow_dispatch`, `permissions` (`contents`, `pages`, `id-token`), and `concurrency` settings intact.
- Left the existing jobs and steps unchanged, including `actions/checkout@v4`, `actions/configure-pages@v5`, `actions/jekyll-build-pages@v1`, `actions/upload-pages-artifact@v3`, and `actions/deploy-pages@v4`.

### Testing
- No automated tests were executed for this workflow-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69884fe2460c832abc1f8e7d3463a92c)